### PR TITLE
Remove importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ attrs==21.4.0
     #   pytest
 charset-normalizer==2.0.10
     # via aiohttp
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -34,9 +34,8 @@ idna==2.10
     # via
     #   -c requirements/constraints.txt
     #   yarl
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   pluggy
     #   pytest
 iniconfig==1.1.1
@@ -70,6 +69,7 @@ typing-extensions==4.0.1
     #   aiohttp
     #   async-timeout
     #   gitpython
+    #   importlib-metadata
     #   yarl
 yarl==1.7.2
     # via aiohttp

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,9 +22,8 @@ idna==2.10
     # via
     #   -c requirements/constraints.txt
     #   requests
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   pluggy
     #   tox
     #   virtualenv
@@ -52,6 +51,8 @@ tox==3.24.5
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
+typing-extensions==4.0.1
+    # via importlib-metadata
 urllib3==1.26.8
     # via requests
 virtualenv==20.13.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,11 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
  
-# Tox and virtualenv require importlib-metadata<3.0 to support python3.5
-# so pinning until both packages drop support for python3.5 &
-# update their required importlib-metadata version constraint
-importlib-metadata<3.0
-
 # aiohttp latest version 3.7.3 requires chardet<4.0, can be removed once aiohttp==4.0.0 is released.
 chardet<4.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,7 +80,7 @@ filelock==3.4.2
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
@@ -100,9 +100,8 @@ idna==2.10
     #   -r requirements/quality.txt
     #   requests
     #   yarl
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -283,11 +282,14 @@ typed-ast==1.5.1
     #   astroid
 typing-extensions==4.0.1
     # via
+    #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   aiohttp
     #   astroid
     #   async-timeout
     #   gitpython
+    #   importlib-metadata
     #   pylint
     #   yarl
 urllib3==1.26.8

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -53,7 +53,7 @@ docutils==0.17.1
     #   sphinx
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -74,12 +74,12 @@ idna==2.10
     #   yarl
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pluggy
     #   pytest
+    #   sphinx
     #   stevedore
 iniconfig==1.1.1
     # via
@@ -148,7 +148,7 @@ smmap==5.0.0
     #   gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -180,6 +180,7 @@ typing-extensions==4.0.1
     #   aiohttp
     #   async-timeout
     #   gitpython
+    #   importlib-metadata
     #   yarl
 urllib3==1.26.8
     # via requests
@@ -193,6 +194,3 @@ zipp==3.7.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,9 +6,8 @@
 #
 click==8.0.3
     # via pip-tools
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   click
     #   pep517
 pep517==0.12.0
@@ -17,6 +16,8 @@ pip-tools==6.4.0
     # via -r requirements/pip-tools.in
 tomli==2.0.0
     # via pep517
+typing-extensions==4.0.1
+    # via importlib-metadata
 wheel==0.37.1
     # via pip-tools
 zipp==3.7.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -49,7 +49,7 @@ coverage[toml]==6.2
     #   pytest-cov
 edx-lint==5.2.1
     # via -r requirements/quality.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -67,9 +67,8 @@ idna==2.10
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   yarl
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   click
     #   pluggy
@@ -179,6 +178,7 @@ typing-extensions==4.0.1
     #   astroid
     #   async-timeout
     #   gitpython
+    #   importlib-metadata
     #   pylint
     #   yarl
 wrapt==1.13.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,7 +32,7 @@ charset-normalizer==2.0.10
     #   aiohttp
 coverage[toml]==6.2
     # via pytest-cov
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -50,9 +50,8 @@ idna==2.10
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   yarl
-importlib-metadata==2.1.2
+importlib-metadata==4.10.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   pluggy
     #   pytest
@@ -108,6 +107,7 @@ typing-extensions==4.0.1
     #   aiohttp
     #   async-timeout
     #   gitpython
+    #   importlib-metadata
     #   yarl
 yarl==1.7.2
     # via


### PR DESCRIPTION
## Description
`importlib-metadata<3.0` constraint was added because of the conflict between `tox` and `virtualenv` requirements for `Python 3.5` support in https://github.com/openedx/pytest-repo-health/pull/63.
Removed the constraint now to update dependencies to latest version with `Python 3.7` and resolve the `make upgrade` job failure.