### PR TITLE
fix: pin charset-normalizer~=2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,9 @@ attrs==21.4.0
     #   aiohttp
     #   pytest
 charset-normalizer==2.0.12
-    # via aiohttp
+    # via
+    #   -c requirements/constraints.txt
+    #   aiohttp
 frozenlist==1.3.0
     # via
     #   aiohttp

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,10 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
 charset-normalizer==2.0.12
-    # via requests
+    # via
+    #   -c requirements/constraints.txt
+    #   requests
 codecov==2.1.12
     # via -r requirements/ci.in
 coverage==6.4.1
@@ -37,7 +39,7 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.0
     # via codecov
 six==1.16.0
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,6 @@ diff-cover<4.2.0
 
 # requests has a constraint idna<3 in it, so pinning it unless requests updates the constraint
 idna<3.0
+
+# requests has a constraint charset-normalizer~=2.0.0 which so the version can't be bumped for now.
+charset-normalizer~=2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ aiosignal==1.2.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -31,12 +31,13 @@ attrs==21.4.0
     #   -r requirements/quality.txt
     #   aiohttp
     #   pytest
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
     #   requests
 charset-normalizer==2.0.12
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
@@ -77,7 +78,7 @@ distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.txt
 filelock==3.7.1
     # via
@@ -192,7 +193,7 @@ pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
     # via diff-cover
-pylint==2.14.1
+pylint==2.14.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -239,7 +240,7 @@ pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/ci.txt
     #   codecov

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,14 +28,15 @@ attrs==21.4.0
     #   -r requirements/test.txt
     #   aiohttp
     #   pytest
-babel==2.10.1
+babel==2.10.3
     # via sphinx
 bleach==5.0.0
     # via readme-renderer
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
 charset-normalizer==2.0.12
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   aiohttp
     #   requests
@@ -138,7 +139,7 @@ pyyaml==6.0
     # via -r requirements/test.txt
 readme-renderer==35.0
     # via -r requirements/doc.in
-requests==2.27.1
+requests==2.28.0
     # via sphinx
 restructuredtext-lint==1.4.0
     # via doc8
@@ -152,7 +153,7 @@ smmap==5.0.0
     #   gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.1
+sphinx==5.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -13,7 +13,7 @@ aiosignal==1.2.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
@@ -32,6 +32,7 @@ attrs==21.4.0
     #   pytest
 charset-normalizer==2.0.12
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   aiohttp
 click==8.1.3
@@ -49,7 +50,7 @@ coverage[toml]==6.4.1
     #   pytest-cov
 dill==0.3.5.1
     # via pylint
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.in
 frozenlist==1.3.0
     # via
@@ -117,7 +118,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.14.1
+pylint==2.14.3
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,6 +28,7 @@ attrs==21.4.0
     #   pytest
 charset-normalizer==2.0.12
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   aiohttp
 coverage[toml]==6.4.1


### PR DESCRIPTION
### Description
- `requests` has a pin `charset-normalizer~=2.0.0` in it so we can't bump the version unless `requests` package resolves the pin. 