### PR TITLE
fix(docs): format the readme properly on PyPI, and a minimal formatting fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,10 @@ Once installed, use this command to run checks::
 
     $ pytest -c <() --noconftest --repo-health --repo-health-path <path to dir with checks> --repo-path <path to repo to check>
 
-The -c and --noconftest options are needed to stop pytest from incorrectly reading configuration files in the repo you are checking.
+The -c and --noconftest options are needed to stop pytest from incorrectly reading configuration files in the repo you are checking::
 
     -c file: load configuration from `file` instead of trying to locate one of the implicit configuration files. Helpful if invocation dir defines "add-opts" in one of its files.
+
     --noconftest: Don't load any conftest.py files. Helpful in case invocation dir/repository has conftest files that change configurations or cause pytest to run unnecessary code.
 
 Other pytest options can be used.  For example, `-k` is helpful for running a subset of checks.

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
     url='https://github.com/edX/pytest-repo-health',
     description='A pytest plugin to report on repository standards conformance',
     long_description=read('README.rst'),
-    long_description_content_type="text/markdown",
+    long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.7",
     install_requires=load_requirements('requirements/base.in'),


### PR DESCRIPTION
Because the content type is declared incorrectly as markdown, the package on PyPI looks like this:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/23789/212349192-565b821f-a653-4489-b978-42cd647769b2.png">

This fixes that, and also correct one infelicity in the README formatting.