### PR TITLE
fix: Remove yanked codecov package to unbreak dev

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in Travis
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,26 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==2.0.12
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.1.0
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.9.0
     # via
     #   tox
     #   virtualenv
-idna==2.10
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
 packaging==23.0
     # via tox
 platformdirs==2.6.2
@@ -32,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -45,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.14
-    # via requests
 virtualenv==20.17.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,17 +31,11 @@ build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 charset-normalizer==2.0.12
     # via
     #   -c requirements/constraints.txt
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
@@ -58,13 +52,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 diff-cover==4.1.1
     # via
@@ -105,9 +95,7 @@ gitpython==3.1.30
 idna==2.10
     # via
     #   -c requirements/constraints.txt
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   requests
     #   yarl
 inflect==6.0.2
     # via jinja2-pluralize
@@ -229,10 +217,6 @@ pyyaml==6.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   codecov
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -283,10 +267,6 @@ typing-extensions==4.4.0
     #   astroid
     #   pydantic
     #   pylint
-urllib3==1.26.14
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 virtualenv==20.17.1
     # via
     #   -r requirements/ci.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,11 @@
 #
 #    make upgrade
 #
+wheel==0.38.4
+    # via -r requirements/pip.in
+
+# The following packages are considered to be unsafe in a requirements file:
 pip==23.0
     # via -r requirements/pip.in
 setuptools==67.1.0
-    # via -r requirements/pip.in
-wheel==0.38.4
     # via -r requirements/pip.in


### PR DESCRIPTION
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

It looks like the migration was never done/finished here. I'm not sure if
we're going to continue using codecov, so I'm not going to add the GHA.
(It would need additional setup, such as provisioning with a token.)