### PR TITLE
fix: force asyncio mistakes to be errors

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -1,9 +1,11 @@
 """
 pytest plugin to test if specific repo follows standards
 """
-import os
-from collections import defaultdict
+
 import datetime
+import os
+import warnings
+from collections import defaultdict
 
 import pytest
 import yaml
@@ -14,6 +16,12 @@ from .utils import get_repo_remote_name
 
 session_data_holder_dict = defaultdict(dict)
 session_data_holder_dict["TIMESTAMP"] = datetime.datetime.now().date()
+
+
+@pytest.fixture(autouse=True)
+def set_warnings() -> None:
+    """Force asyncio mistakes to be errors"""
+    warnings.simplefilter("error", pytest.PytestUnhandledCoroutineWarning)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes https://github.com/openedx/edx-repo-health/issues/356

For example, if this code omits the pytest.mark.asyncio decorator:
```
@health_metadata(
    [MODULE_DICT_KEY],
    {
        "configured": "Flag for existence of renovate configuration",
        "last_pr": "Date of last Pull Request made by renovate",
    }
)
@pytest.mark.asyncio
async def check_renovate(all_results, repo_path, github_repo):
    """
    Checks whether repository contains configuration for renovate and is making PR
    """
```

Without this change, there's a warning that is easy to miss.  This change turns the warning into an error that fails the test.