### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 import sys
 import os
 import shlex
+from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -48,8 +49,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'pytest-repo-health'
-copyright = '2020, edX'
-author = 'edX'
+copyright = f'{datetime.now().year}, Axim Collaborative, Inc' # pylint: disable=redefined-builtin
+author = 'Axim Collaborative, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -109,13 +110,42 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
-
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/pytest-repo-health",
+ "repository_branch": "master",
+ "path_to_docs": "docs/",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 
@@ -128,12 +158,12 @@ html_theme = 'alabaster'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,6 +4,6 @@
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme         # Common theme for all Open edX projects
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 aiohttp==3.8.4
     # via
     #   -r requirements/test.txt
@@ -24,7 +26,11 @@ attrs==23.1.0
     #   -r requirements/test.txt
     #   aiohttp
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
 certifi==2023.5.7
@@ -44,11 +50,10 @@ doc8==1.1.1
 docutils==0.19
     # via
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -94,6 +99,7 @@ multidict==6.0.4
 packaging==23.1
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
@@ -102,9 +108,13 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
     # via
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
 pytest==7.3.1
@@ -132,20 +142,23 @@ requests==2.30.0
 restructuredtext-lint==1.4.0
     # via doc8
 six==1.16.0
-    # via
-    #   bleach
-    #   edx-sphinx-theme
+    # via bleach
 smmap==5.0.0
     # via
     #   -r requirements/test.txt
     #   gitdb
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -166,6 +179,8 @@ tomli==2.0.1
     #   coverage
     #   doc8
     #   pytest
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==2.0.2
     # via requests
 webencodings==0.5.1


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme.
This removes references to the deprecated theme, replaces them with the new
standard theme for the platform, and updates the theme configuraiton to use the
new theme.


**Testing instructions:**
- Run `make docs` or `make html` in the docs directory and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/edx-sphinx-theme/issues/184