### PR TITLE
test(fix): pytest_ignore_collect needs to return None for no opinion

### DIFF
--- a/pytest_repo_health/plugin.py
+++ b/pytest_repo_health/plugin.py
@@ -146,7 +146,7 @@ def pytest_ignore_collect(path, config):
     if config.getoption("repo_health"):
         if "/repo_health" not in str(path):
             return True
-    return False
+    return None
 
 
 # Unused argument "session", but pylint complains if it is renamed "_session"


### PR DESCRIPTION
From https://pytest.org/en/7.4.x/changelog.html#pytest-7-4-0-2023-06-23

> #11081: The norecursedirs check is now performed in a pytest_ignore_collect implementation, so plugins can affect it.
>
> If after updating to this version you see that your norecursedirs setting is not being respected, it means that a conftest or a plugin you use has a bad pytest_ignore_collect implementation. Most likely, your hook returns False for paths it does not want to ignore, which ends the processing and doesn’t allow other plugins, including pytest itself, to ignore the path. The fix is to return None instead of False for paths your hook doesn’t want to ignore.