### PR TITLE
docs: Fix the license stated in README and classifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,9 @@ the coverage at least stays the same before you submit a pull request.
 License
 -------
 
-The code in this repository is licensed under the Apache Software License 2.0 unless
-otherwise noted.
+This software is licensed under the terms of the AGPLv3.
 
-Please see ``LICENSE.txt`` for details.
+Please see ``LICENSE`` for details.
 
 How To Contribute
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
         'Natural Language :: English',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',


### PR DESCRIPTION
Previously both said Apache, but this repository is AGPL3.