### PR TITLE
docs: add arbi-bom team as maintainer

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -18,6 +18,7 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'master' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
+      team_reviewers: "arbi-bom"
       send_success_notification: false
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'pytest-repo-health'
+  description: "A pytest plugin to report on repository standards conformance."
+  links:
+    - url: "https://github.com/openedx/pytest-repo-health"
+      title: "Pytest plugin for repo health checks"
+      icon: "Web"
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:2u-arbi-bom
+  type: 'other'
+  lifecycle: 'production'


### PR DESCRIPTION
## Description
- As per the discussion in Maintenance working group, `arbi-bom` team will maintain this repo from now on. 