### PR TITLE
fix: changed loop to event_loop to sync with latest version of pytest.

### DIFF
--- a/pytest_repo_health/fixtures/github.py
+++ b/pytest_repo_health/fixtures/github.py
@@ -42,7 +42,7 @@ def github_client():
 
 
 @pytest.fixture
-async def github_repo(git_origin_url, github_client, loop):  # pylint: disable=redefined-outer-name, unused-argument
+async def github_repo(git_origin_url, github_client, event_loop):  # pylint: disable=redefined-outer-name, unused-argument
     """
     A fixture to fetch information from the GitHub API about the examined repository.
     Because github.py uses aiohttp, any checks using this fixture must be declared


### PR DESCRIPTION
### Description:

1. Repo health CI workflows failing with fixture `'loop' not found` error.
2. pytest-asyncio 0.24.0+ deprecated `loop` fixture in favor of `event_loop`

**Reference:**
<img width="1097" height="486" alt="image" src="https://github.com/user-attachments/assets/a087dbe3-8a78-42e9-935b-2c0d6d8e8c67" />

### Solution

- Updated `fixtures/github.py` to use `event_loop` instead of deprecated `loop` fixture.
- Ensures compatibility with `pytest-asyncio >= 0.24.0`

**Note:** Re-ran the workflow with current changes and passed successfully.

### Workflow (successful) :
[Repo Health Workflow Call](https://github.com/edx/repo-health-data/actions/runs/17265835052)

### JIRA Ticket:
[BOMS-208](https://2u-internal.atlassian.net/browse/BOMS-208)