### PR TITLE
chore: drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']
         toxenv: ['py', 'quality']
 
     steps:

--- a/pytest_repo_health/__init__.py
+++ b/pytest_repo_health/__init__.py
@@ -5,7 +5,7 @@ and outputting report based on data gathered during checks.
 """
 from typing import Union
 
-__version__ = "3.2.1"
+__version__ = "4.0.0"
 
 
 def health_metadata(parent_path: list, output_keys: dict):

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
     long_description=read('README.rst'),
     long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests"]),
-    python_requires=">=3.11",
+    python_requires=">=3.12",
     install_requires=load_requirements('requirements/base.in'),
     zip_safe=False,
     keywords='pytest edx',
@@ -159,7 +159,6 @@ setup(
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312},quality
+envlist = py312,quality
 
 [doc8]
 max-line-length = 120


### PR DESCRIPTION
## Summary

- Drop Python 3.11 support: remove from CI test matrix, tox envlist, and package classifiers
- Regenerate pinned requirements using Python 3.12
- Bump version to 4.0.0 — dropping Python support is a breaking change, so this is a major version bump

## Context

Python 3.11 is being dropped across the Open edX ecosystem as part of the move
to standardize on Python 3.12. See the tracking issue for the full list of repos:
https://github.com/openedx/public-engineering/issues/499

## Test plan

- [ ] CI passes with Python 3.12 only